### PR TITLE
Always get power settings even in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
     register: macos_power_settings_results
     become: true
     changed_when: False
+    check_mode: no
 
   - name: Set power settings
     # regex_replace('.*(\\d+).*', '\\1') yields just the digit if there is a match, otherwise the value is unchanged.


### PR DESCRIPTION
So that in check mode we can see what changes would be made by the "Set power settings" task.
As it stands, we get an error in check mode: 
`fatal: [localhost]: FAILED! => {"msg": "'dict object' has no attribute 'stdout'"}`